### PR TITLE
Check if import_anymeta table exists when determining known hosts

### DIFF
--- a/mod_import_anymeta_dispatch.erl
+++ b/mod_import_anymeta_dispatch.erl
@@ -121,11 +121,7 @@ observe_dispatch(#dispatch{host=Host, path=Path}, Context) ->
 observe_dispatch_host(#dispatch_host{host=Host, path=Path}, Context) ->
 	KnownHosts = z_depcache:memo(
 		fun() ->
-			[{TableExists}] = z_db:q(
-				"select exists (select tablename from pg_catalog.pg_tables where tablename = 'import_anymeta');",
-				Context
-			),
-			case TableExists of
+			case z_db:table_exists(import_anymeta, Context) of
 				true ->
 					lists:map(
 						fun({H}) -> z_convert:to_list(H) end,

--- a/mod_import_anymeta_dispatch.erl
+++ b/mod_import_anymeta_dispatch.erl
@@ -121,10 +121,19 @@ observe_dispatch(#dispatch{host=Host, path=Path}, Context) ->
 observe_dispatch_host(#dispatch_host{host=Host, path=Path}, Context) ->
 	KnownHosts = z_depcache:memo(
 		fun() ->
-			lists:map(
-				fun({H}) -> z_convert:to_list(H) end,
-				z_db:q("select distinct host from import_anymeta;", Context)
-			)
+			[{TableExists}] = z_db:q(
+				"select exists (select tablename from pg_catalog.pg_tables where tablename = 'import_anymeta');",
+				Context
+			),
+			case TableExists of
+				true ->
+					lists:map(
+						fun({H}) -> z_convert:to_list(H) end,
+						z_db:q("select distinct host from import_anymeta;", Context)
+					);
+				false ->
+					[]
+			end
 		end,
 		anymeta_dispatch_hosts,
 		Context


### PR DESCRIPTION
If the module is enabled but the import_anymeta module is not, you might not have the import_anymeta table which generates many error log messages in a production environment. This checks fixes that problem for the unknown host dispatcher.
