### PR TITLE
Change priority to be more important than mod_alternative_uris

### DIFF
--- a/mod_import_anymeta_dispatch.erl
+++ b/mod_import_anymeta_dispatch.erl
@@ -24,7 +24,7 @@
 
 -mod_title("Import Anymeta Site - Dispatch").
 -mod_description("Dispatcher for old Anymeta urls.").
--mod_prio(300).
+-mod_prio(290).
 
 -export([
     observe_dispatch/2,


### PR DESCRIPTION
mod_alternative_uris and this module have the same priority, which causes issues when one has to catch urls the other doesn't. We believe the solution is to change the priority of one of them. We picked this one.
